### PR TITLE
Hacked something working...

### DIFF
--- a/src/components/NewModal.tsx
+++ b/src/components/NewModal.tsx
@@ -1,12 +1,26 @@
 import { IonApp, IonButton, IonContent, IonNav, IonPage } from '@ionic/react';
-import { useHistory } from 'react-router';
 
-const NewModal: React.FC = () => {
-  const history = useHistory();
+interface NewModalProps {
+  dismiss: (path: string) => void;
+};
+
+const NewModal: React.FC<NewModalProps> = ({dismiss}) => {
+
   const guessedRight = () => {
     console.log('BOO');
-    history.push('/');
+    dismiss("/home");
   };
+
+  const guessedWrong = () => {
+    console.log('BOO2');
+    dismiss("/play");
+  };
+
+  const quitGame = () => {
+    console.log('BOO3');
+    dismiss("/home");
+  };
+
   return (
     <IonPage>
       <IonApp>
@@ -22,14 +36,14 @@ const NewModal: React.FC = () => {
           </IonButton>
           <IonButton
             expand='block'
-            routerLink='play'
+            onClick={guessedWrong}
             className='ion-text-center'
             color='secondary'
           >
             Wrong!
           </IonButton>
           <IonButton
-            routerLink='home'
+            onClick={quitGame}
             expand='block'
             className='ion-text-center'
             color='secondary'

--- a/src/pages/GameBoard.tsx
+++ b/src/pages/GameBoard.tsx
@@ -19,13 +19,18 @@ import {
   IonPage,
 } from '@ionic/react';
 import React, { useRef } from 'react';
+import { useHistory } from 'react-router';
 import NewModal from '../components/NewModal';
 
 const GameBoard: React.FC = () => {
+
+  const history = useHistory();
+
   const pageRef = useRef();
 
-  const handleDismissModal = () => {
+  const handleDismissModal = (path: string) => {
     hideModal();
+    history.push(path);
   };
 
   const handleShowModal = () => {
@@ -33,9 +38,12 @@ const GameBoard: React.FC = () => {
       presentingElement: pageRef.current,
     });
   };
-  const [showModal, hideModal] = useIonModal(NewModal, {
-    dismiss: handleDismissModal,
-  });
+  const [showModal, hideModal] = useIonModal(
+    NewModal
+    , {
+      dismiss: handleDismissModal,
+    }
+  );
   return (
     <IonPage ref={pageRef}>
       <IonApp>


### PR DESCRIPTION
dismiss was a React prop passed to the modal, but never used...

It is now called with a path to navigate to...

And the screen that displays the modal does the navigation....

Not entirely perfect, but working a bit more...